### PR TITLE
Add stop scraping functionality to health and dashboard

### DIFF
--- a/src/Helpers/scraperApiEndpoints.js
+++ b/src/Helpers/scraperApiEndpoints.js
@@ -9,4 +9,5 @@ export const scraperEndpoints = {
     scrapeLogs: "/admin/scrape/logs",
     scrapeHealth: "/admin/scrape/health",
     testAdapter: (name) => `/admin/scrape/test-adapter/${name}`,
+    scrapeStop: (name) => `/admin/scrape/stop/${name}`,
 };

--- a/src/widgets/Scraper/Dashboard/index.jsx
+++ b/src/widgets/Scraper/Dashboard/index.jsx
@@ -10,6 +10,7 @@ import {
     CheckCircle2,
     XCircle,
     AlertTriangle,
+    Square,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "Components/ui/card";
 import { Button } from "Components/ui/button";
@@ -25,7 +26,7 @@ import {
 import { scraperGet, scraperPost } from "Helpers/scraperRequest";
 import { scraperEndpoints } from "Helpers/scraperApiEndpoints";
 import { usePolling } from "hooks/usePolling";
-import { showInfoToast } from "Helpers/toast";
+import { showInfoToast, showSuccessToast } from "Helpers/toast";
 
 const StatsCard = ({ title, value, icon: Icon, description }) => (
     <Card className="hover:shadow-md transition-shadow">
@@ -78,6 +79,8 @@ const ScraperDashboard = () => {
     const [loading, setLoading] = useState(true);
     const [showConfirm, setShowConfirm] = useState(false);
     const [scrapePolling, setScrapePolling] = useState(false);
+    const [stopConfirm, setStopConfirm] = useState(null);
+    const [stoppingAdapters, setStoppingAdapters] = useState({});
 
     const fetchData = useCallback(async () => {
         try {
@@ -128,6 +131,21 @@ const ScraperDashboard = () => {
             showInfoToast("Scrape run started. New jobs will appear in the staging queue shortly.");
             setScrapePolling(true);
             setTimeout(() => setScrapePolling(false), 5 * 60 * 1000);
+        }
+    };
+
+    const handleStopScraping = async (adapterName) => {
+        setStopConfirm(null);
+        setStoppingAdapters((prev) => ({ ...prev, [adapterName]: true }));
+        const res = await scraperPost(
+            scraperEndpoints.scrapeStop(adapterName),
+            {},
+            `Stop ${adapterName}`
+        );
+        setStoppingAdapters((prev) => ({ ...prev, [adapterName]: false }));
+        if (res) {
+            showSuccessToast(`Scraping stopped for ${adapterName}`);
+            fetchData();
         }
     };
 
@@ -221,6 +239,25 @@ const ScraperDashboard = () => {
                                         <div>Last run: {new Date(adapter.lastRun).toLocaleString()}</div>
                                     )}
                                 </div>
+                                <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    className="w-full mt-3"
+                                    disabled={stoppingAdapters[adapter.name]}
+                                    onClick={() => setStopConfirm(adapter.name)}
+                                >
+                                    {stoppingAdapters[adapter.name] ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                                            Stopping...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Square className="mr-2 h-3 w-3" />
+                                            Stop Scraping
+                                        </>
+                                    )}
+                                </Button>
                             </CardContent>
                         </Card>
                     ))}
@@ -254,6 +291,25 @@ const ScraperDashboard = () => {
                             Cancel
                         </Button>
                         <Button onClick={handleScrapeNow}>Start Scraping</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={!!stopConfirm} onOpenChange={() => setStopConfirm(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Stop Scraping</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to stop scraping from <span className="font-medium">{stopConfirm}</span>? Any in-progress scrape for this provider will be halted.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setStopConfirm(null)}>
+                            Cancel
+                        </Button>
+                        <Button variant="destructive" onClick={() => handleStopScraping(stopConfirm)}>
+                            Stop Scraping
+                        </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>

--- a/src/widgets/Scraper/Health/index.jsx
+++ b/src/widgets/Scraper/Health/index.jsx
@@ -6,12 +6,22 @@ import {
     AlertTriangle,
     Play,
     HeartPulse,
+    Square,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "Components/ui/card";
 import { Button } from "Components/ui/button";
 import { Badge } from "Components/ui/badge";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+} from "Components/ui/dialog";
 import { scraperGet, scraperPost } from "Helpers/scraperRequest";
 import { scraperEndpoints } from "Helpers/scraperApiEndpoints";
+import { showSuccessToast } from "Helpers/toast";
 
 const statusConfig = {
     success: { color: "border-green-200 bg-green-50 dark:bg-green-950/20 dark:border-green-900", icon: CheckCircle2, iconColor: "text-green-500", label: "Healthy" },
@@ -19,7 +29,7 @@ const statusConfig = {
     partial: { color: "border-yellow-200 bg-yellow-50 dark:bg-yellow-950/20 dark:border-yellow-900", icon: AlertTriangle, iconColor: "text-yellow-500", label: "Partial" },
 };
 
-const AdapterCard = ({ adapter, onTest }) => {
+const AdapterCard = ({ adapter, onTest, onStop, isStopping }) => {
     const config = statusConfig[adapter.status] || statusConfig.partial;
     const Icon = config.icon;
 
@@ -52,15 +62,36 @@ const AdapterCard = ({ adapter, onTest }) => {
                         Last run: {new Date(adapter.lastRun).toLocaleString()}
                     </p>
                 )}
-                <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full"
-                    onClick={() => onTest(adapter.name)}
-                >
-                    <Play className="mr-2 h-3 w-3" />
-                    Test Adapter
-                </Button>
+                <div className="flex gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="flex-1"
+                        onClick={() => onTest(adapter.name)}
+                    >
+                        <Play className="mr-2 h-3 w-3" />
+                        Test Adapter
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        size="sm"
+                        className="flex-1"
+                        disabled={isStopping}
+                        onClick={() => onStop(adapter.name)}
+                    >
+                        {isStopping ? (
+                            <>
+                                <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                                Stopping...
+                            </>
+                        ) : (
+                            <>
+                                <Square className="mr-2 h-3 w-3" />
+                                Stop Scraping
+                            </>
+                        )}
+                    </Button>
+                </div>
             </CardContent>
         </Card>
     );
@@ -70,18 +101,36 @@ const AdapterHealth = () => {
     const [adapters, setAdapters] = useState([]);
     const [loading, setLoading] = useState(true);
     const [testResults, setTestResults] = useState({});
+    const [stopConfirm, setStopConfirm] = useState(null);
+    const [stoppingAdapters, setStoppingAdapters] = useState({});
+
+    const fetchHealth = async () => {
+        setLoading(true);
+        const res = await scraperGet(scraperEndpoints.scrapeHealth);
+        if (res?.data) {
+            setAdapters(res.data);
+        }
+        setLoading(false);
+    };
 
     useEffect(() => {
-        const fetchHealth = async () => {
-            setLoading(true);
-            const res = await scraperGet(scraperEndpoints.scrapeHealth);
-            if (res?.data) {
-                setAdapters(res.data);
-            }
-            setLoading(false);
-        };
         fetchHealth();
     }, []);
+
+    const handleStopScraping = async (adapterName) => {
+        setStopConfirm(null);
+        setStoppingAdapters((prev) => ({ ...prev, [adapterName]: true }));
+        const res = await scraperPost(
+            scraperEndpoints.scrapeStop(adapterName),
+            {},
+            `Stop ${adapterName}`
+        );
+        setStoppingAdapters((prev) => ({ ...prev, [adapterName]: false }));
+        if (res) {
+            showSuccessToast(`Scraping stopped for ${adapterName}`);
+            fetchHealth();
+        }
+    };
 
     const handleTest = async (name) => {
         setTestResults((prev) => ({ ...prev, [name]: { loading: true } }));
@@ -120,6 +169,8 @@ const AdapterHealth = () => {
                             key={adapter.name}
                             adapter={adapter}
                             onTest={handleTest}
+                            onStop={setStopConfirm}
+                            isStopping={stoppingAdapters[adapter.name]}
                         />
                     ))}
                 </div>
@@ -147,6 +198,25 @@ const AdapterHealth = () => {
                     )}
                 </Card>
             ))}
+
+            <Dialog open={!!stopConfirm} onOpenChange={() => setStopConfirm(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Stop Scraping</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to stop scraping from <span className="font-medium">{stopConfirm}</span>? Any in-progress scrape for this provider will be halted.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setStopConfirm(null)}>
+                            Cancel
+                        </Button>
+                        <Button variant="destructive" onClick={() => handleStopScraping(stopConfirm)}>
+                            Stop Scraping
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
Added the ability to stop active scraping operations for individual adapters across the Health and Dashboard widgets. Users can now halt in-progress scrapes with a confirmation dialog to prevent accidental interruptions.

## Key Changes
- **Stop Scraping Button**: Added a "Stop Scraping" button to adapter cards in both Health and Dashboard views with destructive styling
- **Confirmation Dialog**: Implemented a reusable confirmation dialog that appears before stopping any scraper to prevent accidental operations
- **Loading States**: Added visual feedback with animated spinner and "Stopping..." text while the stop operation is in progress
- **API Integration**: 
  - Added `scrapeStop(name)` endpoint to `scraperApiEndpoints.js`
  - Integrated `handleStopScraping` function that calls the new endpoint and refreshes adapter data
- **Toast Notifications**: Added success toast message when scraping is successfully stopped
- **UI Components**: 
  - Imported `Square` icon from lucide-react for the stop button
  - Imported Dialog components for confirmation modal
  - Refactored button layout in Health widget to accommodate both Test and Stop buttons side-by-side

## Implementation Details
- Stop operations are tracked per adapter using `stoppingAdapters` state object to handle multiple concurrent stop requests
- The confirmation dialog is controlled by `stopConfirm` state that stores the adapter name
- After successful stop, `fetchHealth()` or `fetchData()` is called to refresh the adapter status
- The stop button is disabled during the stopping operation to prevent duplicate requests
- Both widgets follow the same pattern for consistency

https://claude.ai/code/session_01313eFrwdoJchQK58Hs4nmK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added per-adapter "Stop Scraping" controls to both Dashboard and Health views for granular adapter management
* Confirmation dialogs prevent accidental stops with clear visual feedback
* Loading indicators display while stop requests are in progress
* Success notifications confirm when adapters have been stopped
* Dashboard and Health data automatically refresh after stopping to reflect current status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->