### PR TITLE
Fix missing company logos on scraped job approval

### DIFF
--- a/src/widgets/Scraper/Staging/Helpers/index.js
+++ b/src/widgets/Scraper/Staging/Helpers/index.js
@@ -14,19 +14,36 @@ export const fetchStagingJob = async (id) => {
     return scraperGet(scraperEndpoints.stagingDetail(id));
 };
 
-const fetchCompanyLogo = async (companyName) => {
+// Mirrors the AddJobs flow (widgets/Addjobs/index.js getCompanyDetails):
+// look up the company record by name and return the fields the job payload needs.
+const fetchCompanyDetails = async (companyName) => {
     if (!companyName) return null;
     try {
-        const res = await get(`${apiEndpoint.getCompanyDetails}?companyname=${companyName}`);
-        return res?.[0]?.smallLogo || null;
-    } catch {
+        const url = `${apiEndpoint.getCompanyDetails}?companyname=${encodeURIComponent(companyName)}`;
+        const res = await get(url);
+        const data = res?.[0];
+        if (!data) return null;
+        return {
+            imagePath: data.smallLogo || null,
+            companyId: data._id || null,
+        };
+    } catch (err) {
+        console.warn(`[scraper] Company details lookup failed for "${companyName}":`, err);
         return null;
     }
 };
 
+const buildCompanyOverrides = (details, overrides) => {
+    if (!details) return {};
+    const extra = {};
+    if (details.imagePath && !overrides.imagePath) extra.imagePath = details.imagePath;
+    if (details.companyId && !overrides.companyId) extra.companyId = details.companyId;
+    return extra;
+};
+
 export const approveJob = async (id, overrides = {}, companyName = "") => {
-    const logo = overrides.imagePath ? null : await fetchCompanyLogo(companyName);
-    const merged = { ...overrides, ...(logo ? { imagePath: logo } : {}), jdpage: "true" };
+    const details = await fetchCompanyDetails(companyName);
+    const merged = { ...overrides, ...buildCompanyOverrides(details, overrides), jdpage: "true" };
     const body = { overrides: merged };
     return scraperPost(scraperEndpoints.stagingApprove(id), body, "Approve");
 };
@@ -36,7 +53,7 @@ export const rejectJob = async (id, reason = "") => {
 };
 
 export const bulkApproveJobs = async (ids, jobsMap = {}) => {
-    const logoCache = {};
+    const detailsCache = {};
     const perJobOverrides = {};
 
     for (const id of ids) {
@@ -45,11 +62,13 @@ export const bulkApproveJobs = async (ids, jobsMap = {}) => {
             perJobOverrides[id] = { jdpage: "true" };
             continue;
         }
-        if (!(companyName in logoCache)) {
-            logoCache[companyName] = await fetchCompanyLogo(companyName);
+        if (!(companyName in detailsCache)) {
+            detailsCache[companyName] = await fetchCompanyDetails(companyName);
         }
-        const logo = logoCache[companyName];
-        perJobOverrides[id] = { ...(logo ? { imagePath: logo } : {}), jdpage: "true" };
+        perJobOverrides[id] = {
+            ...buildCompanyOverrides(detailsCache[companyName], {}),
+            jdpage: "true",
+        };
     }
 
     return scraperPost(


### PR DESCRIPTION
## Summary

- Root cause: `fetchCompanyLogo` in `src/widgets/Scraper/Staging/Helpers/index.js` did not URL-encode the `companyname` query param, so the lookup silently returned `null` for any multi-word or special-char company name (e.g. `Tata Consultancy`, `Procter & Gamble`). The surrounding `try/catch` swallowed the failure, leaving scraped jobs with no `imagePath`.
- Replaced `fetchCompanyLogo` with `fetchCompanyDetails`, mirroring the AddJobs flow (`src/widgets/Addjobs/index.js:237-241` → FormData at `src/widgets/Addjobs/Helpers/index.js:88`). It now returns both `imagePath` (from `smallLogo`) **and** `companyId`, so the approved job is linked to its company record.
- Applies to all three approval paths: single quick-approve, detail-page approve, and bulk/approve-all. Caches the lookup per company name during bulk.
- Preserves user edits — if the reviewer already overrode `imagePath` or `companyId` in the detail view, the fetched value does not clobber it.
- `console.warn` now surfaces lookup failures instead of silent `null`.

## Test plan

- [ ] Quick-approve a pending job whose company exists in the DB with a single-word name → verify `imagePath` and `companyId` land on the published job.
- [ ] Quick-approve a pending job with a multi-word company name (e.g. `Tata Consultancy Services`) → verify the logo attaches (previously broken due to unencoded space).
- [ ] Quick-approve a pending job with a special-char company name (e.g. `Procter & Gamble`) → verify the logo attaches.
- [ ] Bulk-approve a mix of jobs covering the same company twice → verify only one `/companydetails/get` request per unique name (cache works).
- [ ] Approve-all across >1 page of pending jobs → verify logos attach and no errors in the bulk response.
- [ ] Open a staging detail, edit `imagePath` manually, then approve → verify the manual override is kept (not replaced by fetched logo).
- [ ] Approve a job for a company not yet in the DB → verify the job is still approved without `imagePath`/`companyId`, and the `[scraper] Company details lookup failed` warning is visible in the console.

https://claude.ai/code/session_01W5i71bFaaUqyLJXzR2va9c