### PR TITLE
Add admin Backfill Logos action for pre-fix scraped jobs

### DIFF
--- a/src/widgets/Scraper/Staging/Helpers/index.js
+++ b/src/widgets/Scraper/Staging/Helpers/index.js
@@ -2,6 +2,17 @@ import { scraperGet, scraperPost, scraperDelete } from "Helpers/scraperRequest";
 import { scraperEndpoints } from "Helpers/scraperApiEndpoints";
 import { get } from "Helpers/request";
 import { apiEndpoint } from "Helpers/apiEndpoints";
+import { API } from "Backend";
+
+const silentUpdate = async (url, formData) => {
+    const res = await fetch(`${API}${url}`, {
+        method: "PUT",
+        headers: { "x-api-key": process.env.REACT_APP_API_KEY },
+        body: formData,
+    });
+    if (res.status === 200 || res.status === 201) return res.json().catch(() => ({}));
+    throw new Error(`HTTP ${res.status}`);
+};
 
 export const fetchStagingJobs = async ({ status, source, page = 1, size = 20 }) => {
     const params = new URLSearchParams({ page, size });
@@ -80,6 +91,61 @@ export const bulkApproveJobs = async (ids, jobsMap = {}) => {
 
 export const deleteStagingJob = async (id) => {
     return scraperDelete(scraperEndpoints.stagingDelete(id), "Delete");
+};
+
+// One-off backfill for already-published jobs that were approved before the
+// logo/jdpage fix landed. Fetches the latest `limit` jobs and, for each one
+// that is missing imagePath or jdpage=true, looks up the company record and
+// PUTs a partial update. Returns a summary so the caller can show a toast.
+export const backfillLatestJobs = async (limit = 80, onProgress) => {
+    const res = await get(
+        `${apiEndpoint.getAllJobDetails}?filterData=false&page=1&size=${limit}`
+    );
+    const jobs = res?.data || [];
+    const detailsCache = {};
+    const summary = { total: jobs.length, updated: 0, skipped: 0, failed: 0, errors: [] };
+
+    for (let i = 0; i < jobs.length; i++) {
+        const job = jobs[i];
+        onProgress?.({ current: i + 1, total: jobs.length, companyName: job.companyName });
+
+        const needsLogo = !job.imagePath;
+        const needsJdpage = job.jdpage !== "true" && job.jdpage !== true;
+        if (!needsLogo && !needsJdpage) {
+            summary.skipped++;
+            continue;
+        }
+
+        const updates = {};
+        if (needsJdpage) updates.jdpage = "true";
+
+        if (needsLogo && job.companyName) {
+            if (!(job.companyName in detailsCache)) {
+                detailsCache[job.companyName] = await fetchCompanyDetails(job.companyName);
+            }
+            const details = detailsCache[job.companyName];
+            if (details?.imagePath) updates.imagePath = details.imagePath;
+            if (details?.companyId && !job.companyId) updates.companyId = details.companyId;
+        }
+
+        if (Object.keys(updates).length === 0) {
+            summary.skipped++;
+            continue;
+        }
+
+        const formData = new FormData();
+        Object.entries(updates).forEach(([k, v]) => formData.append(k, v));
+
+        try {
+            await silentUpdate(`${apiEndpoint.updateJobDetails}${job._id}`, formData);
+            summary.updated++;
+        } catch (err) {
+            summary.failed++;
+            summary.errors.push({ id: job._id, companyName: job.companyName, error: err?.message });
+        }
+    }
+
+    return summary;
 };
 
 export const fetchAllPendingJobs = async () => {

--- a/src/widgets/Scraper/Staging/Helpers/index.js
+++ b/src/widgets/Scraper/Staging/Helpers/index.js
@@ -14,19 +14,36 @@ export const fetchStagingJob = async (id) => {
     return scraperGet(scraperEndpoints.stagingDetail(id));
 };
 
-const fetchCompanyLogo = async (companyName) => {
+// Mirrors the AddJobs flow (widgets/Addjobs/index.js getCompanyDetails):
+// look up the company record by name and return the fields the job payload needs.
+const fetchCompanyDetails = async (companyName) => {
     if (!companyName) return null;
     try {
-        const res = await get(`${apiEndpoint.getCompanyDetails}?companyname=${companyName}`);
-        return res?.[0]?.smallLogo || null;
-    } catch {
+        const url = `${apiEndpoint.getCompanyDetails}?companyname=${encodeURIComponent(companyName)}`;
+        const res = await get(url);
+        const data = res?.[0];
+        if (!data) return null;
+        return {
+            imagePath: data.smallLogo || null,
+            companyId: data._id || null,
+        };
+    } catch (err) {
+        console.warn(`[scraper] Company details lookup failed for "${companyName}":`, err);
         return null;
     }
 };
 
+const buildCompanyOverrides = (details, overrides) => {
+    if (!details) return {};
+    const extra = {};
+    if (details.imagePath && !overrides.imagePath) extra.imagePath = details.imagePath;
+    if (details.companyId && !overrides.companyId) extra.companyId = details.companyId;
+    return extra;
+};
+
 export const approveJob = async (id, overrides = {}, companyName = "") => {
-    const logo = overrides.imagePath ? null : await fetchCompanyLogo(companyName);
-    const merged = { ...overrides, ...(logo ? { imagePath: logo } : {}), jdpage: "true" };
+    const details = await fetchCompanyDetails(companyName);
+    const merged = { ...overrides, ...buildCompanyOverrides(details, overrides), jdpage: "true" };
     const body = { overrides: merged };
     return scraperPost(scraperEndpoints.stagingApprove(id), body, "Approve");
 };
@@ -36,7 +53,7 @@ export const rejectJob = async (id, reason = "") => {
 };
 
 export const bulkApproveJobs = async (ids, jobsMap = {}) => {
-    const logoCache = {};
+    const detailsCache = {};
     const perJobOverrides = {};
 
     for (const id of ids) {
@@ -45,11 +62,13 @@ export const bulkApproveJobs = async (ids, jobsMap = {}) => {
             perJobOverrides[id] = { jdpage: "true" };
             continue;
         }
-        if (!(companyName in logoCache)) {
-            logoCache[companyName] = await fetchCompanyLogo(companyName);
+        if (!(companyName in detailsCache)) {
+            detailsCache[companyName] = await fetchCompanyDetails(companyName);
         }
-        const logo = logoCache[companyName];
-        perJobOverrides[id] = { ...(logo ? { imagePath: logo } : {}), jdpage: "true" };
+        perJobOverrides[id] = {
+            ...buildCompanyOverrides(detailsCache[companyName], {}),
+            jdpage: "true",
+        };
     }
 
     return scraperPost(

--- a/src/widgets/Scraper/Staging/index.jsx
+++ b/src/widgets/Scraper/Staging/index.jsx
@@ -11,6 +11,7 @@ import {
     ChevronRight,
     Inbox,
     ExternalLink,
+    ImageDown,
 } from "lucide-react";
 import { Card, CardContent } from "Components/ui/card";
 import { Button } from "Components/ui/button";
@@ -32,7 +33,7 @@ import {
     DialogDescription,
     DialogFooter,
 } from "Components/ui/dialog";
-import { fetchStagingJobs, approveJob, rejectJob, bulkApproveJobs, deleteStagingJob, fetchAllPendingJobs } from "./Helpers";
+import { fetchStagingJobs, approveJob, rejectJob, bulkApproveJobs, deleteStagingJob, fetchAllPendingJobs, backfillLatestJobs } from "./Helpers";
 import { showInfoToast, showErrorToast } from "Helpers/toast";
 
 const timeAgo = (dateStr) => {
@@ -60,6 +61,10 @@ const StagingQueue = () => {
     const [actionLoading, setActionLoading] = useState(null);
     const [showApproveAllConfirm, setShowApproveAllConfirm] = useState(false);
     const [approveAllLoading, setApproveAllLoading] = useState(false);
+    const [showBackfillConfirm, setShowBackfillConfirm] = useState(false);
+    const [backfillLoading, setBackfillLoading] = useState(false);
+    const [backfillProgress, setBackfillProgress] = useState(null);
+    const [backfillLimit, setBackfillLimit] = useState(80);
 
     const totalPages = Math.ceil(totalCount / filters.size);
 
@@ -155,6 +160,28 @@ const StagingQueue = () => {
         setShowBulkConfirm(false);
     };
 
+    const handleBackfill = async () => {
+        setBackfillLoading(true);
+        setBackfillProgress({ current: 0, total: backfillLimit });
+        try {
+            const summary = await backfillLatestJobs(backfillLimit, setBackfillProgress);
+            const msg = `Backfill: ${summary.updated} updated, ${summary.skipped} skipped, ${summary.failed} failed (of ${summary.total})`;
+            showInfoToast(msg);
+            if (summary.errors?.length) {
+                summary.errors.slice(0, 5).forEach((e) =>
+                    showErrorToast(`Failed: ${e.companyName || e.id}${e.error ? ` — ${e.error}` : ""}`)
+                );
+            }
+        } catch (err) {
+            console.error("Backfill failed:", err);
+            showErrorToast("Backfill failed. See console for details.");
+        } finally {
+            setBackfillLoading(false);
+            setBackfillProgress(null);
+            setShowBackfillConfirm(false);
+        }
+    };
+
     const handleApproveAll = async () => {
         setApproveAllLoading(true);
         try {
@@ -211,11 +238,24 @@ const StagingQueue = () => {
                 <h1 className="text-2xl font-bold tracking-tight">Staging Queue</h1>
                 <div className="flex items-center gap-2">
                     <Badge variant="secondary">{totalCount} total</Badge>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setShowBackfillConfirm(true)}
+                        disabled={backfillLoading || approveAllLoading || bulkLoading}
+                    >
+                        {backfillLoading ? (
+                            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                        ) : (
+                            <ImageDown className="mr-1 h-4 w-4" />
+                        )}
+                        Backfill Logos
+                    </Button>
                     {totalCount > 0 && filters.status === "pending" && (
                         <Button
                             size="sm"
                             onClick={() => setShowApproveAllConfirm(true)}
-                            disabled={approveAllLoading || bulkLoading}
+                            disabled={approveAllLoading || bulkLoading || backfillLoading}
                         >
                             {approveAllLoading ? (
                                 <Loader2 className="mr-1 h-4 w-4 animate-spin" />
@@ -441,6 +481,43 @@ const StagingQueue = () => {
                                 <Loader2 className="h-4 w-4 animate-spin mr-2" />
                             ) : null}
                             Approve Selected
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={showBackfillConfirm} onOpenChange={(open) => { if (!backfillLoading) setShowBackfillConfirm(open); }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Backfill Company Logos</DialogTitle>
+                        <DialogDescription>
+                            Scan the latest N published jobs and, for each one missing a logo, look up the company and set <code className="font-mono text-xs">imagePath</code>, <code className="font-mono text-xs">companyId</code>, and <code className="font-mono text-xs">jdpage="true"</code>. Safe to re-run — already-complete jobs are skipped.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Jobs to scan (latest)</label>
+                        <Input
+                            type="number"
+                            min={1}
+                            max={500}
+                            value={backfillLimit}
+                            onChange={(e) => setBackfillLimit(Math.max(1, Math.min(500, Number(e.target.value) || 1)))}
+                            disabled={backfillLoading}
+                        />
+                        {backfillLoading && backfillProgress && (
+                            <p className="text-sm text-muted-foreground">
+                                Processing {backfillProgress.current} / {backfillProgress.total}
+                                {backfillProgress.companyName ? ` — ${backfillProgress.companyName}` : ""}
+                            </p>
+                        )}
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setShowBackfillConfirm(false)} disabled={backfillLoading}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleBackfill} disabled={backfillLoading}>
+                            {backfillLoading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+                            Start Backfill
                         </Button>
                     </DialogFooter>
                 </DialogContent>


### PR DESCRIPTION
## Summary

Follow-up to #13 — that PR fixed **future** scraped approvals, but the ~80 jobs approved before it landed are still missing `imagePath` and `jdpage="true"`. This adds an admin-only "Backfill Logos" button on the Staging Queue page to repair them in place.

- **`backfillLatestJobs(limit, onProgress)`** in `src/widgets/Scraper/Staging/Helpers/index.js` — fetches the latest N jobs via `/jd/get`, and for each one missing `imagePath` or `jdpage="true"` looks up the company and PUTs a **partial** `/jd/update/{id}` with only the fields being backfilled. Reuses the same `fetchCompanyDetails` helper introduced in #13, with a per-company-name cache.
- **`silentUpdate`** — thin `fetch()` wrapper used instead of the shared `updateData` so we don't fire 80 success toasts at the user.
- **Idempotent** — jobs that already have both fields are skipped, so the action can be re-run safely.
- **UI** — button in the Staging Queue header next to "Approve All", with a confirm dialog that lets the admin pick the scan size (default 80, max 500), shows live `Processing X / Y — company` progress, and ends with a single summary toast `Backfill: X updated, Y skipped, Z failed (of N)`.

## Test plan

- [ ] Click "Backfill Logos" with default 80 → verify summary toast fires and jobs that were missing logos now render with them on the public site.
- [ ] Re-run immediately → verify the second run reports `0 updated, 80 skipped` (idempotency check).
- [ ] Pick a job that had a manually-uploaded logo → verify it is **not** touched (skipped because `imagePath` present and `jdpage === "true"`).
- [ ] Cancel mid-way is not supported (best-effort one-shot) — confirm the dialog stays open during the run and can't be dismissed.
- [ ] Enter `0` or a negative in the scan size → verify it clamps to 1.
- [ ] Enter `9999` → verify it clamps to 500.
- [ ] Run with an unknown-company job (no DB match) → verify that job is counted in `skipped` if nothing else needed, or updated with only `jdpage` if it was missing that.
- [ ] Confirm only the three fields (`imagePath`, `companyId`, `jdpage`) are sent in the PUT body — the rest of the job record is preserved by the backend's partial-update semantics.
- [ ] After the backfill runs cleanly once, consider removing the button (or leave it in place for future recoveries — it's idempotent).

https://claude.ai/code/session_01W5i71bFaaUqyLJXzR2va9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Backfill Logos" functionality to update company logos and details for job listings.
  * Users can configure the number of jobs to process (1–500).
  * Real-time progress tracking and summary reporting showing updated, skipped, and failed job counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->