### PR TITLE
Reorder footer above comment line for Instagram-channel CTA

### DIFF
--- a/src/Components/Canvas/CareersAtTechBanner.jsx
+++ b/src/Components/Canvas/CareersAtTechBanner.jsx
@@ -12,7 +12,7 @@ const HARDCODED_DEGREE = "B.Tech / B.E. / M.Tech / BCA / MCA";
 const HARDCODED_BATCH = "2024 / 2025 / 2026 / 2027";
 
 const CareersAtTechBanner = (props) => {
-    const { ctaDetails, canvasCss, companyDetails, igbannertitle, jobinfo } = props;
+    const { ctaDetails, canvasCss, companyDetails, igbannertitle, jobinfo, instaChannelCTA } = props;
     const { companyName, experience, salary, location, role } = jobinfo;
     const { largeLogo } = companyDetails;
     const [bannerTitle, setBannerTitle] = useState(null);
@@ -59,7 +59,7 @@ const CareersAtTechBanner = (props) => {
                     </div>
                 </div>
 
-                <div className={styles.lower}>
+                <div className={`${styles.lower}${instaChannelCTA ? ` ${styles.lower_reordered}` : ""}`}>
                     <div className={styles.canvas_details}>
                         <p contentEditable="true">
                             <span className={styles.tag}>Degree</span> : <span>{HARDCODED_DEGREE}</span>
@@ -82,12 +82,14 @@ const CareersAtTechBanner = (props) => {
                                 <span className={styles.tag}>Location</span> : <span contentEditable="true">{location}</span>
                             </p>
                         )}
-                        <p contentEditable="true">
-                            <span className={styles.tag}>{ctaDetails?.ctaTitle}</span>
-                            <span className={styles.tag} style={{ color: "#0050ff" }}>
-                                {ctaDetails?.ctaLine}
-                            </span>
-                        </p>
+                        {!instaChannelCTA && (
+                            <p contentEditable="true">
+                                <span className={styles.tag}>{ctaDetails?.ctaTitle}</span>
+                                <span className={styles.tag} style={{ color: "#0050ff" }}>
+                                    {ctaDetails?.ctaLine}
+                                </span>
+                            </p>
+                        )}
                     </div>
 
                     <div className={styles.footer}>
@@ -98,6 +100,19 @@ const CareersAtTechBanner = (props) => {
                             Follow <span>@careersattech</span> to get regular Job updates.
                         </p>
                     </div>
+
+                    {/* Instagram-channel CTA only: comment line drops below the footer
+                        so its 👇 points down to the apply-link sticker. */}
+                    {instaChannelCTA && (
+                        <div className={styles.cta_strip}>
+                            <p contentEditable="true">
+                                <span className={styles.tag}>{ctaDetails?.ctaTitle}</span>
+                                <span className={styles.tag} style={{ color: "#0050ff" }}>
+                                    {ctaDetails?.ctaLine}
+                                </span>
+                            </p>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/Components/Canvas/canvas.module.scss
+++ b/src/Components/Canvas/canvas.module.scss
@@ -193,6 +193,39 @@ $gridBoxSize: 30px;
     }
 }
 
+// Reordered lower section — only for the "Join instagram channel" CTA.
+// Footer moves up one line (just below Location); the comment line drops to its
+// own strip at the very bottom. Box height trimmed so the three blocks
+// (details 16 + footer 2 + comment strip 3 = 21 grid) fill the same space and
+// nothing overflows the canvas.
+.lower_reordered {
+    .canvas_details {
+        height: 16 * $gridBoxSize;
+    }
+}
+
+.cta_strip {
+    background-color: #f0f8ff;
+    font-family: "Helvetica Neue", sans-serif;
+    height: 3 * $gridBoxSize;
+    padding: 0px 0px 0px 120px;
+    display: flex;
+    align-items: center;
+
+    p {
+        color: #000000;
+        margin: 4.5px 0px;
+        font-weight: 500;
+        font-size: $detailFontSize;
+        line-height: 70px;
+    }
+
+    .tag {
+        font-weight: 600;
+        color: #000000;
+    }
+}
+
 .flex {
     display: flex;
     justify-content: space-between;

--- a/src/Components/Canvas/index.js
+++ b/src/Components/Canvas/index.js
@@ -222,8 +222,10 @@ function Canvas(props) {
         ...props,
         jobinfo,
         ctaDetails,
-        canvasCss
-    }), [props, jobinfo, ctaDetails, canvasCss]);
+        canvasCss,
+        // CTA id 4 = "Join instagram channel for apply link 👇" — triggers footer/comment reorder
+        instaChannelCTA: selectedCTA === 4
+    }), [props, jobinfo, ctaDetails, canvasCss, selectedCTA]);
 
     return (
         <div>


### PR DESCRIPTION
When the "Join instagram channel for apply link" CTA (id 4) is selected on the CareersAtTech banner, move the Follow footer up to sit just below the Location line and drop the comment/CTA line to its own strip at the very bottom, so its down-arrow points to the apply-link sticker.

All other CTAs keep the existing layout (comment line last inside the details box, footer below). Block heights are re-balanced (details 16 + footer 2 + comment strip 3 grid units) so the reordered section fills the same space without overflowing the canvas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Instagram channel call-to-action variant for the Careers banner with optimized layout.
  * Call-to-action text can now be positioned below the footer when this option is enabled for improved visual organization and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->